### PR TITLE
Fix memory leak in promise_manager

### DIFF
--- a/.changes/fix-memory-leak.md
+++ b/.changes/fix-memory-leak.md
@@ -1,5 +1,5 @@
 ---
-"@qubit/client": patch:bug
+"@qubit-rs/client": patch:bug
 ---
 
 Fix memory leak in promise manager due to holding references to resolved promises.

--- a/.changes/fix-memory-leak.md
+++ b/.changes/fix-memory-leak.md
@@ -1,0 +1,5 @@
+---
+"@qubit/client": patch:bug
+---
+
+Fix memory leak in promise manager due to holding references to resolved promises.

--- a/packages/client/src/util/promise_manager.ts
+++ b/packages/client/src/util/promise_manager.ts
@@ -19,6 +19,7 @@ export function create_promise_manager() {
     resolve: (response: RpcResponse<unknown>) => {
       const handler = promises[response.id];
       if (handler) {
+        delete promises[response.id];
         handler(response);
       }
     },


### PR DESCRIPTION
A reference was kept to all promises, not just outstanding promises, leading to a memory leak of all response objects.