### PR TITLE
feat: index barrel file

### DIFF
--- a/.changes/index-barrel-file.md
+++ b/.changes/index-barrel-file.md
@@ -1,0 +1,5 @@
+---
+"qubit": patch
+---
+
+Alter router type generation to re-export all types.

--- a/examples/authentication/auth-demo/src/bindings/index.ts
+++ b/examples/authentication/auth-demo/src/bindings/index.ts
@@ -12,4 +12,6 @@
 
 import type { Query } from "@qubit-rs/client";
 
+export type { Query } from "@qubit-rs/client";
+
 export type QubitServer = { echo_cookie: Query<[], string>, secret_endpoint: Query<[], string> };

--- a/examples/chaos/bindings/index.ts
+++ b/examples/chaos/bindings/index.ts
@@ -20,4 +20,14 @@ import type { Metadata } from "./Metadata.ts";
 import type { User } from "./User.ts";
 import type { Test } from "./Test.ts";
 
+export type { Query } from "@qubit-rs/client";
+export type { Mutation } from "@qubit-rs/client";
+export type { Subscription } from "@qubit-rs/client";
+export type { NestedStruct } from "./NestedStruct.ts";
+export type { MyEnum } from "./MyEnum.ts";
+export type { UniqueType } from "./UniqueType.ts";
+export type { Metadata } from "./Metadata.ts";
+export type { User } from "./User.ts";
+export type { Test } from "./Test.ts";
+
 export type QubitServer = { version: Query<[], string>, count: Mutation<[], number>, countdown: Subscription<[min: number, max: number, ], number>, array: Query<[], Array<string>>, enum_test: Query<[], MyEnum>, array_type: Query<[], Array<UniqueType>>, user: { someHandler: Query<[_id: string, ], User>, create: Mutation<[name: string, email: string, age: number, ], User>, list: Query<[], Array<Test>>, asdf: Query<[], null> } };

--- a/examples/chat-room-react/src/bindings/index.ts
+++ b/examples/chat-room-react/src/bindings/index.ts
@@ -15,4 +15,9 @@ import type { Mutation } from "@qubit-rs/client";
 import type { Subscription } from "@qubit-rs/client";
 import type { ChatMessage } from "./ChatMessage.ts";
 
+export type { Query } from "@qubit-rs/client";
+export type { Mutation } from "@qubit-rs/client";
+export type { Subscription } from "@qubit-rs/client";
+export type { ChatMessage } from "./ChatMessage.ts";
+
 export type QubitServer = { get_name: Query<[], string>, send_message: Mutation<[message: string, ], null>, list_online: Subscription<[], Array<string>>, list_messages: Subscription<[], Array<ChatMessage>> };

--- a/examples/counter/bindings/index.ts
+++ b/examples/counter/bindings/index.ts
@@ -14,4 +14,8 @@ import type { Mutation } from "@qubit-rs/client";
 import type { Query } from "@qubit-rs/client";
 import type { Subscription } from "@qubit-rs/client";
 
+export type { Mutation } from "@qubit-rs/client";
+export type { Query } from "@qubit-rs/client";
+export type { Subscription } from "@qubit-rs/client";
+
 export type QubitServer = { increment: Mutation<[], null>, decrement: Mutation<[], null>, add: Mutation<[n: number, ], null>, get: Query<[], number>, countdown: Subscription<[], number> };

--- a/examples/hello-world/bindings/index.ts
+++ b/examples/hello-world/bindings/index.ts
@@ -12,4 +12,6 @@
 
 import type { Query } from "@qubit-rs/client";
 
+export type { Query } from "@qubit-rs/client";
+
 export type QubitServer = { hello_world: Query<[], string> };


### PR DESCRIPTION
Re-export all types within `index.ts`.

Closes #81 